### PR TITLE
Update version numbers of deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,8 +53,8 @@ runtime. After running `cargo init` add the following lines to your
 
 ```toml
 # Example, use the version numbers you need
-tide = "0.14.0"
-async-std = { version = "1.6.0", features = ["attributes"] }
+tide = "0.15.0"
+async-std = { version = "1.8.0", features = ["attributes"] }
 ```
 
 ## Examples


### PR DESCRIPTION
Using the old version numbers will result in a build failure.